### PR TITLE
Misc improvements for version 1.8: allow MemoryUI to be opened using launch.json, various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.8.1
+* Fix and improve settings descriptions
+* Reduce number of linter warnings
+
+## 1.8.0
+* Allow MemoryUI to be opened using launch.json
+* Jump to address also when user confirms his entry by pressing return key
+
 ## 1.7.3
 * Debugger now also uses breakpoints on labels
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "riscv-venus",
 	"displayName": "RISC-V Venus Simulator",
-	"version": "1.7.6",
+	"version": "1.8.1",
 	"publisher": "hm",
 	"description": "RISC-V Venus Simulator embedded in VS Code",
 	"author": {

--- a/package.json
+++ b/package.json
@@ -105,32 +105,32 @@
 				"riscv-venus.forceAlignedAddressing": {
 					"type": "boolean",
 					"default": false,
-					"description": "Force Aligned Addressing?"
+					"description": "Force aligned addressing?"
 				},
 				"riscv-venus.mutableText": {
 					"type": "boolean",
 					"default": true,
-					"description": "Mutable Text? Can't write into text segment if true."
+					"description": "Allow write into text segment?"
 				},
 				"riscv-venus.ecallOnlyExit": {
 					"type": "boolean",
 					"default": false,
-					"description": "Can Exit only with ecall (10)?"
+					"description": "Can exit only with ecall (10)?"
 				},
 				"riscv-venus.setRegesOnInit": {
 					"type": "boolean",
 					"default": true,
-					"description": "Initialize Registers with default Values?"
+					"description": "Initialize registers with default values?"
 				},
 				"riscv-venus.allowAccessBtnStackHeap": {
 					"type": "boolean",
 					"default": false,
-					"description": "Allow Access Between Stack and Heap?"
+					"description": "Allow access between stack and heap?"
 				},
 				"riscv-venus.maxSteps": {
 					"type": "integer",
 					"default": -1,
-					"description": "Max number of steps: (Negative means ignored)"
+					"description": "Max number of steps (negative removes limit):"
 				},
 				"riscv-venus.onlyShowUsedRegs": {
 					"type": "boolean",
@@ -297,7 +297,7 @@
 							},
 							"stopAtBreakpoints": {
 								"type": "boolean",
-								"description": "If execution should stop at Breakpoints. If this is false execution runs until the program execution finishes.",
+								"description": "If execution should stop at breakpoints. If this is false, execution runs until the program execution finishes.",
 								"default": true
 							},
 							"openViews": {
@@ -310,7 +310,7 @@
 										"Robot",
 										"LED Matrix",
 										"Seven Segment Board",
-										"Assembly"
+										"Memory"
 									]
 								},
 								"uniqueItems": true
@@ -321,7 +321,7 @@
 									"x": 10,
 									"y": 10
 								},
-								"description": "The wanted Size of the Led Matrix. The parameter must be in the format: {\"x\": 10, \"y\": 10}"
+								"description": "The wanted size of the Led Matrix. The parameter must be in the format: {\"x\": 10, \"y\": 10}"
 							}
 						}
 					}
@@ -337,7 +337,8 @@
 						"openViews": [
 							"Robot",
 							"LED Matrix",
-							"Seven Segment Board"
+							"Seven Segment Board",
+							"Memory"
 						],
 						"ledMatrixSize": {
 							"x": 10,
@@ -360,7 +361,7 @@
 					},
 					{
 						"label": "Venus Debug: Launch current file",
-						"description": "Currently not properly working if there are Breakpoints across files.",
+						"description": "Currently not properly working if there are breakpoints across files.",
 						"body": {
 							"type": "venus",
 							"request": "launch",
@@ -384,7 +385,7 @@
 					},
 					{
 						"label": "Venus Debug: All Options",
-						"description": "This config list all the options available. You can delete the options you dont't need. This config debugs the current file",
+						"description": "This config list all the options available. You can delete the options you don't need. This config debugs the current file",
 						"body": {
 							"type": "venus",
 							"request": "launch",
@@ -395,7 +396,8 @@
 							"openViews": [
 								"Robot",
 								"LED Matrix",
-								"Seven Segment Board"
+								"Seven Segment Board",
+								"Memory"
 							],
 							"ledMatrixSize": {
 								"x": 10,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,10 +27,10 @@ const runMode: 'external' | 'server' | 'inline' = 'inline';
 
 export function activate(context: vscode.ExtensionContext) {
 
-	VenusLedMatrixUI.createNewInstance(context.extensionUri, new UIState(new LedMatrix(10, 10)))
-	VenusRobotUI.createNewInstance(context.extensionUri)
-	VenusSevenSegBoardUI.createNewInstance(context.extensionUri)
-	MemoryUI.createNewInstance()
+	VenusLedMatrixUI.createNewInstance(context.extensionUri, new UIState(new LedMatrix(10, 10)));
+	VenusRobotUI.createNewInstance(context.extensionUri);
+	VenusSevenSegBoardUI.createNewInstance(context.extensionUri);
+	MemoryUI.createNewInstance(context.extensionUri);
 	venusTerminal.create();
 
 	context.subscriptions.push(vscode.commands.registerCommand('extension.riscv-venus.getProgramName', config => {
@@ -76,7 +76,7 @@ export function activate(context: vscode.ExtensionContext) {
 	  }));
 
 	context.subscriptions.push(vscode.commands.registerCommand('riscv-venus.openMemory', async config => {
-		MemoryUI.getInstance().show(context.extensionUri);
+		MemoryUI.getInstance().show();
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('riscv-venus.openTerminal', async config => {

--- a/src/memoryui/memoryUI.html
+++ b/src/memoryui/memoryUI.html
@@ -1022,7 +1022,7 @@
 									</div>
 									<div class="field-body is-expanded">
 										<input id="memMove" class="input is-small"
-											onblur="if (this.value !== ''){driver.moveMemoryLocation(this.value);this.value='';}"
+											onchange="if (this.value !== ''){driver.moveMemoryLocation(this.value);this.value='';}"
 											spellcheck="false">
 									</div>
 								</div>

--- a/src/memoryui/memoryUI.js
+++ b/src/memoryui/memoryUI.js
@@ -5,10 +5,10 @@
  * They might be useful for future development, though.
  */
 (function removeLegacyHTMLElements() {
-	document.getElementById('register-tab-view').remove()
-	document.getElementById('cache-tab-view').remove()
-	document.getElementById('navigation-bar').remove()
-})()
+	document.getElementById('register-tab-view').remove();
+	document.getElementById('cache-tab-view').remove();
+	document.getElementById('navigation-bar').remove();
+})();
 
 const vscode = acquireVsCodeApi();
 
@@ -17,24 +17,24 @@ const vscode = acquireVsCodeApi();
  */
 window.driver = {
 	moveMemoryJump: () => {
-		const jumpSelect = document.getElementById('address-jump')
-		const memorySegment = jumpSelect.value
-		jumpSelect.selectedIndex = 0
+		const jumpSelect = document.getElementById('address-jump');
+		const memorySegment = jumpSelect.value;
+		jumpSelect.selectedIndex = 0;
 		vscode.postMessage({
 			command: 'moveMemoryJump',
 			segment: memorySegment
-		})
+		});
 	},
 	moveMemoryLocation: (memAddress) => {
 		vscode.postMessage({
 			command: 'moveMemoryLocation',
 			memAddress
-		})
+		});
 	},
 	moveMemoryUp: () => vscode.postMessage({command: 'moveMemoryUp'}),
 	moveMemoryDown: () => vscode.postMessage({command: 'moveMemoryDown'}),
 	updateRegMemDisplay: (displayType) => vscode.postMessage({command: 'updateDisplayType', displayType}),
-}
+};
 
 
 /**
@@ -47,12 +47,12 @@ window.addEventListener('message', event => {
 	switch (message.command) {
 		case 'loadState':
 			let state = message.uiState;
-			console.log('Loading inital state')
+			console.log('Loading inital state');
 			break;
 		case 'updateMemory':
-			const { lines } = message
+			const { lines } = message;
 			for (const {rowIdx, rowAddr, bytes} of lines) {
-				renderMemoryRow(rowIdx,rowAddr, bytes)
+				renderMemoryRow(rowIdx,rowAddr, bytes);
 			}
 			break;
 	}
@@ -64,14 +64,14 @@ window.addEventListener('message', event => {
 function cleanTableRow(row) {
 	for (const n of row.childNodes) {
 		if (!(n instanceof HTMLTableCellElement)) {
-			row.removeChild(n)
+			row.removeChild(n);
 		}
 	}
-	return row
+	return row;
 }
 
 function getDisplayType() {
-	return document.getElementById('display-settings').value
+	return document.getElementById('display-settings').value;
 }
 
 /**
@@ -82,21 +82,21 @@ function getDisplayType() {
  * @param {Array<string>} bytes in hex, dec, ascii or unsigned encoding
  */
 function renderMemoryRow(rowIdx,rowAddr, bytes) {
-	let row = document.getElementById("mem-row-" + rowIdx)
-	row = cleanTableRow(row)
-	const tdAddress = row.childNodes[0]
+	let row = document.getElementById("mem-row-" + rowIdx);
+	row = cleanTableRow(row);
+	const tdAddress = row.childNodes[0];
 	if (rowAddr >= 0) {
-		tdAddress.innerText = "0x" + rowAddr.toString(16).toUpperCase().padStart(8, "0")
+		tdAddress.innerText = "0x" + rowAddr.toString(16).toUpperCase().padStart(8, "0");
 		for (let i = 0; i < 4; i++) {
-			const byte = bytes[i]
-			const tdByte = row.childNodes[i + 1]
-			tdByte.innerText = byte
+			const byte = bytes[i];
+			const tdByte = row.childNodes[i + 1];
+			tdByte.innerText = byte;
 		}
 	} else {
-		tdAddress.innerText = "----------"
+		tdAddress.innerText = "----------";
 		for (i = 0; i < 4; i++) {
-			const tdByte = row.childNodes[i + 1]
-			tdByte.innerText = "--"
+			const tdByte = row.childNodes[i + 1];
+			tdByte.innerText = "--";
 		}
 	}
 }

--- a/src/memoryui/memoryUI.ts
+++ b/src/memoryui/memoryUI.ts
@@ -89,11 +89,12 @@ export class MemoryUI {
 			'Memory',
 			column ? column : vscode.ViewColumn.Beside,
 			{
-				// Enable javascript in the webview
+				// Enable JavaScript in the webview
 				enableScripts: true,
-
-				// And restrict the webview to only loading content from our extension's `src/memoryui` directory.
-				localResourceRoots: [vscode.Uri.joinPath(MemoryUI._extensionUri, 'src', 'memoryui')]
+				// Restrict the webview to only loading content from our extension's `src/memoryui` directory.
+				localResourceRoots: [vscode.Uri.joinPath(MemoryUI._extensionUri, 'src', 'memoryui')],
+				// Make sure that select box state is kept while another tab is shown
+				retainContextWhenHidden: true
 			}
 		);
 

--- a/src/memoryui/memoryUI.ts
+++ b/src/memoryui/memoryUI.ts
@@ -275,4 +275,4 @@ const MemorySegmentAdresses = new Map<string, number>([
 	[MemorySegmentOption.DATA, MemorySegments.STATIC_BEGIN],
 	[MemorySegmentOption.HEAP, MemorySegments.HEAP_BEGIN],
 	[MemorySegmentOption.STACK, MemorySegments.STACK_BEGIN],
-])
+]);

--- a/src/sevensegboard/venusSevenSegBoardUI.ts
+++ b/src/sevensegboard/venusSevenSegBoardUI.ts
@@ -36,12 +36,13 @@ export class VenusSevenSegBoardUI {
 	}
 
 	private constructor(extensionUri?: vscode.Uri, uiState?: UIState) {
-		if (extensionUri)
-			VenusSevenSegBoardUI._extensionUri = extensionUri
+		if (extensionUri) { 
+			VenusSevenSegBoardUI._extensionUri = extensionUri;
+		}	
 		if (uiState) {
 			VenusSevenSegBoardUI._uiState = uiState;
 		} else {
-			VenusSevenSegBoardUI._uiState = new UIState()
+			VenusSevenSegBoardUI._uiState = new UIState();
 		}
 	}
 
@@ -65,7 +66,7 @@ export class VenusSevenSegBoardUI {
 		if (VenusSevenSegBoardUI.instance?._panel) {
 			VenusSevenSegBoardUI.instance._panel.reveal();
 		} else {
-			this._addPanel();
+			this._addPanel(column);
 		}
 	}
 

--- a/src/venusDebug.ts
+++ b/src/venusDebug.ts
@@ -705,7 +705,8 @@ export class VenusDebugSession extends LoggingDebugSession {
 			{VenusSevenSegBoardUI.getInstance().show(ViewColumn.Two);}
 		else if (view === "Assembly")
 			{AssemblyView.getInstance().show(ViewColumn.Two);}
-
+		else if (view === "Memory")
+			{MemoryUI.getInstance().show();}
 	}
 
 	/** Updates the Decorators in Assemblyview. This means lines are marked, for example the current active line that is debugged. */


### PR DESCRIPTION
- Allow MemoryUI to be opened using launch.json (as a prerequisite, handle extensionUri like venusSevenSegBoard does)
- Jump to address also when user confirms his entry by pressing return key (and not only when edit box is left)
- Fix confusing description for "Mutable Text" and harmonize letter case and writing style
- Fix: pass parameter to subfunction to take effect
- Satisfy linter regarding semicolons to get rid of warnings cleanly
- Fix issue that select box state is lost when view was hidden due to another tab selected
- Bump version to v1.8